### PR TITLE
Fix issue with image download

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Sensors can be purchased an the [FYTA Shop](https://fyta.de/collections/all/prod
 	### **WORK IN PROGRESS**
 -->
 
+### 0.1.5 (2025-03-23)
+-   fix token handling when downloading plant images
+
 ### 0.1.4 (2025-02-23)
 -   minor changes due to publishing in ioBroker.repository:latest
 

--- a/io-package.json
+++ b/io-package.json
@@ -1,7 +1,7 @@
 {
     "common": {
         "name": "fyta",
-        "version": "0.1.4",
+        "version": "0.1.5",
         "news": {
             "0.1.4": {
                 "en": "minor changes due to publishing to ioBroker.repository:latest",

--- a/main.js
+++ b/main.js
@@ -357,7 +357,7 @@ class Fyta extends utils.Adapter {
 								this.log.debug(`Skipped downloading file /${this.name}/${filename}`);
 								return;
 							}
-							this.downloadImage(plant[property], filename, token)
+							this.downloadImage(plant[property], filename, resultLogin.token)
 								.then((filename) => {
 									this.setStateOrCreate(`${plantObjectID}.${property}_local`, filename, {
 										common: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.fyta",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Adapter to connect ioBroker to FYTA plant sensors",
   "author": {
     "name": "muffin142",


### PR DESCRIPTION
The variable `token` was not defined, but passed down to `downloadImage`.

Instead, now the existing (and populated) `resultLogin.token` is used.

Verified fix against my own iobroker server and fyta account. Confirmed working.